### PR TITLE
Configure the basic layer in the layer.yaml file

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python3
 """Actions module."""
 
 import os

--- a/actions/actions.py
+++ b/actions/actions.py
@@ -6,10 +6,6 @@ import sys
 
 sys.path.append("lib")
 
-from charms.layer.basic import activate_venv  # NOQA E402
-
-activate_venv()
-
 from charmhelpers.core.hookenv import action_fail  # NOQA E402
 from lib_cron import CronHelper  # NOQA E402
 from lib_logrotate import LogrotateHelper  # NOQA E402

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,2 +1,6 @@
 includes:
   - 'layer:basic'
+options:
+    basic:
+        use_venv: true
+repo: https://github.com/canonical/charm-logrotated

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 # Include python requirements here
+git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
+charms.reactive

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Include python requirements here
-git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
+charmhelpers
 charms.reactive

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
+charmhelpers
 charms.reactive
 pytest
 pytest-cov

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,4 @@
-charmhelpers
+git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
 charms.reactive
 pytest
 pytest-cov


### PR DESCRIPTION
Integration with tics are with issues because pylint is complaining about the layer basic imports. Configuring in the layer.yaml is the right approach. See the [docs](https://charmsreactive.readthedocs.io/en/latest/layer-basic.html#layer-configuration)