### PR TITLE
Workaround indirect build issue for reactive charm [1]

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,9 +3,8 @@ parts:
   charm:
     source: .
     plugin: reactive
-    reactive-charm-build-arguments:
-      - --binary-wheels-from-source
-      - -v
+    build-environment:
+      - PIP_CONSTRAINT: $CRAFT_PART_BUILD/constraints.txt
     build-snaps:
       - charm/latest/edge
 platforms:

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+# See https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428
+setuptools_scm < 8.2.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,2 @@
 # See https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428
-setuptools_scm < 8.2.0
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,5 @@
 # See https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428
 setuptools_scm < 8.2.0; python_version < "3.10"
+# Before all issues about license file, and the new mechanism of including one dynamically
+# https://github.com/jaraco/skeleton/pull/171
+setuptools < 80.3.0


### PR DESCRIPTION

This is the way charmcraft team suggest us to do, and they will not add workaround in charmcraft level (like they did for other plugins) since reactive plugin is unofficially deprecated, and they don't maintain it as well (the build process is in `charm` snap)

Workaround indirect build issue for reactive charm [1].

[1]: https://github.com/canonical/solutions-engineering-automation/issues/218
